### PR TITLE
speeding up tcpIP connection

### DIFF
--- a/rohdeschwarz/bus/tcp.py
+++ b/rohdeschwarz/bus/tcp.py
@@ -82,6 +82,8 @@ class TcpBus(QueryMixin):
 
         """
         self.__socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # to speed up every request, turn off Nagle's algorithm:
+        self.__socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self.timeout_ms = 1000
         self.__socket.connect((address, port))
 


### PR DESCRIPTION
Every Tcp Request needs 0.2s which makes measurements quite slow. Now there is now delay before sending. 

Furthermore as a remark, there are few places in code, where an arbitrary pause is introduced. Imho, this can be removed, too. At least I do not had any Issues about that.